### PR TITLE
tooltip fixes dragonflight

### DIFF
--- a/Compat.lua
+++ b/Compat.lua
@@ -1,4 +1,7 @@
 local API = {}; OutfitterAPI = API;
+local IS_WOW1002   = select(4, GetBuildInfo()) >= 100002 or nil;
+
+OutfitterAPI.IsWoW1002 = IS_WOW1002;
 
 function API:GetContainerItemLink(...)
     if C_Container and C_Container.GetContainerItemLink then return C_Container.GetContainerItemLink(...) end

--- a/Outfitter.lua
+++ b/Outfitter.lua
@@ -7269,15 +7269,18 @@ function Outfitter._ExtendedCompareTooltip:Construct()
 		end
 	end)
 
-	GameTooltip:HookScript("OnHide", function ()
-		self:HideCompareItems()
-	end)
-
-	GameTooltip:HookScript("OnTooltipSetItem", function ()
-		if not IsModifiedClick("COMPAREITEMS") then
+	if not OutfitterAPI.IsWoW1002 then
+		GameTooltip:HookScript("OnHide", function ()
 			self:HideCompareItems()
-		end
-	end)
+		end)
+
+		GameTooltip:HookScript("OnTooltipSetItem", function ()
+			if not IsModifiedClick("COMPAREITEMS") then
+				self:HideCompareItems()
+			end
+		end)
+
+	end
 
 	self.Tooltips = {}
 	self.NumTooltipsShown = 0
@@ -7326,6 +7329,7 @@ function Outfitter._ExtendedCompareTooltip:ShowCompareItem()
 	self.AnchorToTooltip = nil
 
 	for vIndex, vShoppingTooltip in ipairs(GameTooltip.shoppingTooltips) do
+		if OutfitterAPI.IsWoW1002 then Mixin(vShoppingTooltip, GameTooltipDataMixin) end
 		local _, vShoppingLink = vShoppingTooltip:GetItem()
 		local vShoppingItemInfo = Outfitter:GetItemInfoFromLink(vShoppingLink)
 
@@ -7449,6 +7453,8 @@ function Outfitter._ExtendedCompareTooltip:ShoppingItemIsShown(pItemInfo)
 			break
 		end
 
+		if OutfitterAPI.IsWoW1002 then Mixin(vTooltip, GameTooltipDataMixin) end
+
 		local _, vTooltipLink = vTooltip:GetItem()
 		local vTooltipItemInfo = Outfitter:GetItemInfoFromLink(vTooltipLink)
 
@@ -7485,6 +7491,17 @@ function Outfitter._ExtendedCompareTooltip:AddShoppingLink(pTitle, pItemName, pL
 
 	if not vTooltip then
 		vTooltip = CreateFrame("GameTooltip", "OutfitterCompareTooltip"..self.NumTooltipsShown, UIParent, "ShoppingTooltipTemplate")
+		if OutfitterAPI.IsWoW1002 then
+		  Mixin(vTooltip, GameTooltipDataMixin)
+		  vTooltip:SetScript("OnUpdate", function ()
+			  if not TooltipUtil.ShouldDoItemComparison() then
+				  self:HideCompareItems()
+			  end
+		  end)
+		  vTooltip:SetScript("OnHide", function ()
+			  self:HideCompareItems()
+		  end)
+		end
 		vTooltip:SetOwner(UIParent, "ANCHOR_NONE")
 		vTooltip:Hide()
 

--- a/OutfitterInventory.lua
+++ b/OutfitterInventory.lua
@@ -1274,10 +1274,6 @@ function Outfitter._InventoryCache:InventorySlotContainsItem(inventorySlot, outf
 	local items = {}
 	local numItems = self:FindAllItemsOrAlt(outfitItem, nil, items)
 
-	if inventorySlot == "HeadSlot" then
-		Outfitter:DebugTable(items, "items")
-	end
-
 	if numItems == 0 then
 --		Outfitter:DebugMessage("InventorySlotContainsItem: OutfitItem not found")
 --		Outfitter:DebugTable(outfitItem, "InventorySlotContainsItem: OutfitItem")

--- a/OutfitterInventory.lua
+++ b/OutfitterInventory.lua
@@ -166,12 +166,12 @@ function Outfitter:ParseItemLink2(pItemLink)
 		return
 	end
 
-	local _, _, vLinkType = pItemLink:find("|H([^:]+):")
+	local _, _, vLinkType = string.find(pItemLink, "|H([^:]+):")
 	if vLinkType ~= "item" then
 		return
 	end
 
-	local vStartIndex, vEndIndex, vCodeStrings, vName = pItemLink:find("|Hitem:([^|]*)|h%[([^%]]*)%]|h")
+	local vStartIndex, vEndIndex, vCodeStrings, vName = string.find(pItemLink, "|Hitem:([^|]*)|h%[([^%]]*)%]|h")
 	-- self:DebugMessage("start %s, end %s, codes %s, name %s", tostring(vStartIndex), tostring(vEndIndex), tostring(vCodeStrings), tostring(vName))
 
 	if not vCodeStrings then


### PR DESCRIPTION
These are some fixes to make tooltips partly working again in dragonflight.

Still missing is backwards compatiblity with prepatch and replacement for the hook scripts