### PR TITLE
fix: scaling issue to prevent cascading scales

### DIFF
--- a/Libraries/LibDropdown-1.0.lua
+++ b/Libraries/LibDropdown-1.0.lua
@@ -92,7 +92,7 @@ end
 new, del = lib.new, lib.del
 
 -- Make the frame match the tooltip
-local function InitializeFrame(frame, parent)
+local function InitializeFrame(frame)
 	if TooltipBackdropTemplateMixin then
 		frame.layoutType = GameTooltip.layoutType
 		if GameTooltip.layoutType then
@@ -109,9 +109,9 @@ local function InitializeFrame(frame, parent)
 			frame:SetBackdropBorderColor(GameTooltip:GetBackdropBorderColor())
 		end
 	end
-	
-	if not parent then
-		frame:SetScale(GameTooltip:GetScale())
+	frame:SetScale(GameTooltip:GetScale())
+	if (frame:GetEffectiveScale() ~= GameTooltip:GetEffectiveScale()) then -- consider applied SetIgnoreParentScale() on GameTooltip regarding scaling of the frame
+		frame:SetScale(frame:GetScale() * GameTooltip:GetEffectiveScale() / frame:GetEffectiveScale())
 	end
 end
 
@@ -625,7 +625,7 @@ end
 
 function AcquireFrame(parent, toplevel)
 	local f = tremove(framePool) or NewDropdownFrame()
-	InitializeFrame(f, parent) -- set the look of the frame
+	InitializeFrame(f) -- set the look of the frame
 	f.released = false
 	f.buttons = f.buttons or {}
 	f:SetParent(parent or UIParent)

--- a/Libraries/LibDropdown-1.0.lua
+++ b/Libraries/LibDropdown-1.0.lua
@@ -110,7 +110,7 @@ local function InitializeFrame(frame, parent)
 		end
 	end
 	
-	if not parent
+	if not parent then
 		frame:SetScale(GameTooltip:GetScale())
 	end
 end

--- a/Libraries/LibDropdown-1.0.lua
+++ b/Libraries/LibDropdown-1.0.lua
@@ -92,7 +92,7 @@ end
 new, del = lib.new, lib.del
 
 -- Make the frame match the tooltip
-local function InitializeFrame(frame)
+local function InitializeFrame(frame, parent)
 	if TooltipBackdropTemplateMixin then
 		frame.layoutType = GameTooltip.layoutType
 		if GameTooltip.layoutType then
@@ -109,7 +109,10 @@ local function InitializeFrame(frame)
 			frame:SetBackdropBorderColor(GameTooltip:GetBackdropBorderColor())
 		end
 	end
-	frame:SetScale(GameTooltip:GetScale())
+	
+	if not parent
+		frame:SetScale(GameTooltip:GetScale())
+	end
 end
 
 local editBoxCount = 1
@@ -622,7 +625,7 @@ end
 
 function AcquireFrame(parent, toplevel)
 	local f = tremove(framePool) or NewDropdownFrame()
-	InitializeFrame(f) -- set the look of the frame
+	InitializeFrame(f, parent) -- set the look of the frame
 	f.released = false
 	f.buttons = f.buttons or {}
 	f:SetParent(parent or UIParent)

--- a/Libraries/LibDropdown-1.0.lua
+++ b/Libraries/LibDropdown-1.0.lua
@@ -92,7 +92,7 @@ end
 new, del = lib.new, lib.del
 
 -- Make the frame match the tooltip
-local function InitializeFrame(frame, parent)
+local function InitializeFrame(frame)
 	if TooltipBackdropTemplateMixin then
 		frame.layoutType = GameTooltip.layoutType
 		if GameTooltip.layoutType then
@@ -109,10 +109,8 @@ local function InitializeFrame(frame, parent)
 			frame:SetBackdropBorderColor(GameTooltip:GetBackdropBorderColor())
 		end
 	end
-	
-	if not parent then
-		frame:SetScale(GameTooltip:GetScale())
-	end
+	frame:SetScale(GameTooltip:GetScale())
+	frame:SetIgnoreParentScale(true);
 end
 
 local editBoxCount = 1
@@ -625,7 +623,7 @@ end
 
 function AcquireFrame(parent, toplevel)
 	local f = tremove(framePool) or NewDropdownFrame()
-	InitializeFrame(f, parent) -- set the look of the frame
+	InitializeFrame(f) -- set the look of the frame
 	f.released = false
 	f.buttons = f.buttons or {}
 	f:SetParent(parent or UIParent)


### PR DESCRIPTION
This fixes #14. To prevent cascading scales calling `SetScale()` in `InitializeFrame()` is only necessary on the main frame of the dropdown.